### PR TITLE
[Merge after testing] Support for Separate Postgres Instance for Database Pool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+export DB_POOL_DB_ADAPTER=postgres
+export DB_POOL_DB_HOST=localhost
+export DB_POOL_DB_USERNAME=postgres
+export DB_POOL_DB_PASSWORD=""
+export DB_POOL_DB_NAME_PREFIX=db_pool_database_
+export DB_POOL_DB_DUMP_URL=https://example.com/db_dump.sql.gz

--- a/.iex.exs
+++ b/.iex.exs
@@ -1,0 +1,16 @@
+alias DbPool.Repo
+alias DbPool.Core
+alias DbPool.Core.{
+  Pool,
+  Database,
+  Scheduler,
+  Importer,
+  Deleter,
+  BulkCreator
+}
+import DbPool.Utils
+import Ecto.Query, warn: false
+defmodule Utils do
+  def delete_all(), do: Repo.all(Database) |> Enum.each(&(Deleter.run(&1)))
+  def import(), do: BulkCreator.run()
+end

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,9 +38,10 @@ MAINTAINER Codemancers <team@codemancers.com>
 
 RUN apk add --no-cache bash libssl1.0 openssh mysql-client postgresql postgresql-contrib
 COPY --from=application /db-pool/_build /db-pool/_build
+COPY --from=application /db-pool/scripts /db-pool/scripts
 
 ENV MIX_ENV prod
 ENV PORT 4000
 
 EXPOSE 4000
-CMD /db-pool/_build/prod/rel/db_pool/bin/db_pool foreground
+CMD /db-pool/scripts/run_release

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN mix deps.get --only prod && \
 FROM alpine:3.8
 MAINTAINER Codemancers <team@codemancers.com>
 
-RUN apk add --no-cache bash libssl1.0 openssh mysql-client postgresql postgresql-contrib
+RUN apk add --no-cache bash libssl1.0 wget gzip openssh mysql-client postgresql postgresql-contrib
 COPY --from=application /db-pool/_build /db-pool/_build
 COPY --from=application /db-pool/scripts /db-pool/scripts
 

--- a/lib/db_pool.ex
+++ b/lib/db_pool.ex
@@ -6,16 +6,31 @@ defmodule DbPool do
   Contexts are also responsible for managing your data, regardless
   if it comes from the database, an external API or others.
   """
+  alias DbPool.Core.Pool
+
   @supported_adapters ~w(postgres mysql)
 
   def init() do
     DbPool.Config.set_configs_from_env()
     validate_db_adapter()
+    set_pool()
   end
 
   defp validate_db_adapter() do
     db_adapter = Application.get_env(:db_pool, :db_adapter)
     unless db_adapter in @supported_adapters, do:
       raise "[!] Invalid Database Adapter."
+  end
+
+  defp set_pool() do
+    pool = %Pool{
+      host: Application.fetch_env!(:db_pool, :db_host),
+      username: Application.fetch_env!(:db_pool, :db_username),
+      password: Application.get_env(:db_pool, :db_password),
+      adapter:  Application.fetch_env!(:db_pool, :db_adapter),
+      name_prefix:  Application.fetch_env!(:db_pool, :db_name_prefix),
+      dump_url:  Application.fetch_env!(:db_pool, :db_dump_url)
+    }
+    Application.put_env(:db_pool, :pool, pool)
   end
 end

--- a/lib/db_pool/config.ex
+++ b/lib/db_pool/config.ex
@@ -1,6 +1,8 @@
 defmodule DbPool.Config do
   def set_configs_from_env do
     for {env_var, config_key, type} <- configs() do
+      value = System.get_env(env_var)
+      unless value, do: raise "[!] You need to provide #{env_var}"
       set_config(System.get_env(env_var), config_key, type)
     end
   end
@@ -9,7 +11,10 @@ defmodule DbPool.Config do
     [
       {"DB_POOL_DB_DUMP_URL", :db_dump_url, :string},
       {"DB_POOL_DB_ADAPTER", :db_adapter, :string},
-      {"DB_POOL_DB_NAME", :db_name, :string}
+      {"DB_POOL_DB_NAME_PREFIX", :db_name_prefix, :string},
+      {"DB_POOL_DB_HOST", :db_host, :string},
+      {"DB_POOL_DB_USERNAME", :db_username, :string},
+      {"DB_POOL_DB_PASSWORD", :db_password, :string}
     ]
   end
 

--- a/lib/db_pool/core/importer.ex
+++ b/lib/db_pool/core/importer.ex
@@ -1,56 +1,73 @@
 defmodule DbPool.Core.Importer do
+  alias DbPool.Core
+  alias DbPool.Core.Pool
   alias DbPool.Core.Database
   alias DbPool.Repo
+
+  import DbPool.Utils
 
   require Logger
 
   def run(%Database{} = database) do
-    Database.status_changeset(database, "importing")
+    database
+    |> Database.status_changeset("importing")
+    |> Repo.update!()
   end
 
   def start_importing(database) do
     # download database dump using wget
     # import it to database name
     tmp_directory = "/tmp/#{DateTime.utc_now |> DateTime.to_unix}"
-    db_dump_url = Application.get_env(:db_pool, :db_dump_url)
-    db_adapter = Application.get_env(:db_pool, :db_adapter)
+    pool = Core.get_active_pool!()
+    db_dump_url = pool.dump_url
 
-    # download and extract the dump zip file
-    File.mkdir_p!(tmp_directory)
-    {_, 0} = System.cmd("wget", [db_dump_url], stderr_to_stdout: true, cd: tmp_directory)
+    with :ok <- File.mkdir_p!(tmp_directory),
+         {_, 0} <- System.cmd("wget", [db_dump_url], stderr_to_stdout: true, cd: tmp_directory),
+         db_dump_filename_gz <- db_dump_url |> String.split("/") |> List.last(),
+         {_, 0} = System.cmd("gzip", ["-f", "-d", db_dump_filename_gz], stderr_to_stdout: true, cd: tmp_directory),
+         db_dump_filename <- db_dump_filename_gz |> String.replace(".gz", ""),
+         :ok <- import_db(pool, database, db_dump_filename, tmp_directory)
+    do
+      # update status
+      database
+      |> Database.status_changeset("imported")
+      |> Repo.update!()
 
-    db_dump_filename_gz = db_dump_url |> String.split("/") |> List.last
-
-    {msg, code} = System.cmd("gzip", ["-d", db_dump_filename_gz], stderr_to_stdout: true, cd: tmp_directory)
-    cond do
-      code == 1 and !String.contains?(msg, "already exists") ->
-        raise "[!] Error Occurred while decompressing db dump"
-      true -> :ok
+      Logger.info "The database has been imported"
+      Core.remove_errors(pool)
+    else
+      {msg, error_code} ->
+        error_msg = "[#{error_code}] #{msg}"
+        Core.log_error(pool, error_msg)
+        :error
     end
+  end
 
-    db_dump_filename = db_dump_filename_gz |> String.replace(".gz", "")
-
-    case db_adapter do
+  defp import_db(%Pool{} = pool, database, db_dump_filename, tmp_directory) do
+    case pool.adapter do
       "postgres" -> import_postgres_db(database, db_dump_filename, tmp_directory)
       "mysql" -> import_mysql_db(database, db_dump_filename, tmp_directory)
     end
-
-    # update status
-    database
-    |> Database.status_changeset("imported")
-    |> Repo.update!()
-
-    Logger.info "The database has been imported"
   end
 
   defp import_postgres_db(%Database{} = database, filename, dir) do
-    {_, 0} = System.cmd("createdb", [database.name])
-    {_, 0} = System.cmd("psql", ["-d", database.name, "-f", "./#{filename}"], stderr_to_stdout: true, cd: dir)
+    pool = Core.get_active_pool!()
+
+    with {_, 0} <- System.cmd("createdb", [database.name], env: get_envs(pool)),
+         {_, 0} <- System.cmd("psql", ["-d", database.name, "-f", "./#{filename}"], stderr_to_stdout: true, cd: dir, env: get_envs(pool))
+    do
+      :ok
+    else
+      {msg, error_code} ->
+        Logger.error("[#{error_code}] #{msg}")
+        {"couldn't import database", 1}
+    end
   end
 
   defp import_mysql_db(%Database{} = database, filename, dir) do
     # create database if it doesn't exist
-    config = [database: database.name, username: "root"]
+    pool = Core.get_active_pool!()
+    config = [database: database.name, username: pool.username, password: pool.password]
     case Ecto.Adapters.MySQL.storage_up(config) do
       :ok ->
         Logger.info "The database has been created"
@@ -63,8 +80,14 @@ defmodule DbPool.Core.Importer do
     end
 
     # import database. Adapter has got no method :(
-    cmd = "mysql --user root #{database.name} < #{filename}"
-    {_, 0} = System.cmd("sh", ["-c", cmd], stderr_to_stdout: true,
-                                           cd: dir)
+    cmd = "mysql #{database.name} < #{filename}"
+    case System.cmd("sh", ["-c", cmd], stderr_to_stdout: true, cd: dir, env: get_envs(pool)) do
+      {_, 0} ->
+        :ok
+
+      {msg, error_code} ->
+        Logger.error("[#{error_code}] #{msg}")
+        {"couldn't import database", 1}
+    end
   end
 end

--- a/lib/db_pool/core/importer.ex
+++ b/lib/db_pool/core/importer.ex
@@ -17,12 +17,11 @@ defmodule DbPool.Core.Importer do
   def start_importing(database) do
     # download database dump using wget
     # import it to database name
-    tmp_directory = "/tmp/#{DateTime.utc_now |> DateTime.to_unix}"
     pool = Core.get_active_pool!()
     db_dump_url = pool.dump_url
 
-    with :ok <- File.mkdir_p!(tmp_directory),
-         {_, 0} <- System.cmd("wget", [db_dump_url], stderr_to_stdout: true, cd: tmp_directory),
+    with tmp_directory <- System.tmp_dir!(),
+         {_, 0} <- System.cmd("wget", ["-N", db_dump_url], stderr_to_stdout: true, cd: tmp_directory),
          db_dump_filename_gz <- db_dump_url |> String.split("/") |> List.last(),
          {_, 0} = System.cmd("gzip", ["-f", "-d", db_dump_filename_gz], stderr_to_stdout: true, cd: tmp_directory),
          db_dump_filename <- db_dump_filename_gz |> String.replace(".gz", ""),

--- a/lib/db_pool/core/pool.ex
+++ b/lib/db_pool/core/pool.ex
@@ -1,0 +1,10 @@
+defmodule DbPool.Core.Pool do
+  defstruct host: nil,
+    username: nil,
+    password: nil,
+    name_prefix: "db_pool_database_",
+    adapter: nil,
+    dump_url: nil,
+    errored: false,
+    error_message: ""
+end

--- a/lib/db_pool/core/scheduler.ex
+++ b/lib/db_pool/core/scheduler.ex
@@ -13,7 +13,7 @@ defmodule DbPool.Core.Scheduler do
     Deleter
   }
 
-  @interval_5_mins_msec 5 * 60 * 1000
+  @interval_5_mins_msec 30 * 1000 # 5 * 60 * 1000
 
   @doc """
   Starts a Scheduler and kicks off the loop
@@ -73,8 +73,13 @@ defmodule DbPool.Core.Scheduler do
       |> DbPool.Repo.one
 
     if next_database_to_import do
-      Importer.start_importing(next_database_to_import)
-      Process.send(self(), :import_if_any, [])
+      case Importer.start_importing(next_database_to_import) do
+        :ok ->
+          Process.send(self(), :import_if_any, [])
+
+        :error ->
+          set_update_timer(:import_if_any)
+      end
     else
       set_update_timer(:import_if_any)
     end
@@ -89,8 +94,13 @@ defmodule DbPool.Core.Scheduler do
       |> DbPool.Repo.one
 
     if next_database_to_delete do
-      Deleter.start_deleting(next_database_to_delete)
-      Process.send(self(), :delete_if_any, [])
+      case Deleter.start_deleting(next_database_to_delete) do
+        :ok ->
+          Process.send(self(), :delete_if_any, [])
+
+        :error ->
+          set_update_timer(:delete_if_any)
+      end
     else
       set_update_timer(:delete_if_any)
     end

--- a/lib/db_pool/core/scheduler.ex
+++ b/lib/db_pool/core/scheduler.ex
@@ -13,7 +13,7 @@ defmodule DbPool.Core.Scheduler do
     Deleter
   }
 
-  @interval_5_mins_msec 30 * 1000 # 5 * 60 * 1000
+  @interval_5_mins_msec 5 * 60 * 1000
 
   @doc """
   Starts a Scheduler and kicks off the loop

--- a/lib/db_pool/utils.ex
+++ b/lib/db_pool/utils.ex
@@ -1,0 +1,14 @@
+defmodule DbPool.Utils do
+  alias DbPool.Core.Pool
+
+  @postgres_envs ~w(PGHOST PGUSER PGPASSWORD)
+  @mysql_envs ~w(MYSQL_HOST USER MYSQL_PWD)
+
+  def get_envs(), do: get_envs(Application.fetch_env!(:db_pool, :pool))
+  def get_envs(%Pool{} = pool) do
+    values = [pool.host, pool.username, pool.password]
+    get_envs(pool.adapter, values)
+  end
+  def get_envs("postgres", values), do: Enum.zip(@postgres_envs, values)
+  def get_envs("mysql", values), do: Enum.zip(@mysql_envs, values)
+end

--- a/lib/db_pool_web/controllers/database_controller.ex
+++ b/lib/db_pool_web/controllers/database_controller.ex
@@ -10,7 +10,6 @@ defmodule DbPoolWeb.DatabaseController do
     stats = Core.database_stats()
     databases = Core.list_databases(status, page)
     {error_message, errored} = Core.get_error()
-    IO.inspect Core.get_error()
 
     conn =
       if errored do

--- a/lib/db_pool_web/controllers/database_controller.ex
+++ b/lib/db_pool_web/controllers/database_controller.ex
@@ -8,8 +8,17 @@ defmodule DbPoolWeb.DatabaseController do
     page = String.to_integer(params["page"] || "1")
     status = params["status"] || "all"
     stats = Core.database_stats()
-
     databases = Core.list_databases(status, page)
+    {error_message, errored} = Core.get_error()
+    IO.inspect Core.get_error()
+
+    conn =
+      if errored != 0 do
+        put_flash(conn, :error, error_message)
+      else
+        conn
+      end
+
     render(conn, "index.html", databases: databases,
                                page: page, stats: stats,
                                status: status)
@@ -70,6 +79,10 @@ defmodule DbPoolWeb.DatabaseController do
       {:error, %Ecto.Changeset{} = _changeset} ->
         conn
         |> put_flash(:error, "Failed to create :(")
+        |> redirect(to: database_path(conn, :index))
+      {:error, msg} ->
+        conn
+        |> put_flash(:error, msg)
         |> redirect(to: database_path(conn, :index))
     end
   end

--- a/lib/db_pool_web/controllers/database_controller.ex
+++ b/lib/db_pool_web/controllers/database_controller.ex
@@ -13,7 +13,7 @@ defmodule DbPoolWeb.DatabaseController do
     IO.inspect Core.get_error()
 
     conn =
-      if errored != 0 do
+      if errored do
         put_flash(conn, :error, error_message)
       else
         conn

--- a/mix.exs
+++ b/mix.exs
@@ -57,7 +57,7 @@ defmodule DbPool.Mixfile do
     [
       "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
-      "test": ["ecto.create --quiet", "ecto.migrate", "test"]
+      test: ["ecto.create --quiet", "ecto.migrate", "test"]
     ]
   end
 end

--- a/scripts/run_release
+++ b/scripts/run_release
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd "$(dirname "$0")"
+../_build/prod/rel/db_pool/bin/db_pool migrate && ../_build/prod/rel/db_pool/bin/db_pool foreground


### PR DESCRIPTION
1. use separate postgres instnace to create databases
2. abstract out pool

Note: This will require updating helm-charts. See, `.env.example` for reference.